### PR TITLE
Added styles for tooltip-button

### DIFF
--- a/assets/sass/all-digital/_components.scss
+++ b/assets/sass/all-digital/_components.scss
@@ -16,3 +16,4 @@
 @import 'components/circle';
 @import 'components/color';
 @import 'components/key-value';
+@import 'components/tooltip-button';

--- a/assets/sass/all-digital/components/_tooltip-button.scss
+++ b/assets/sass/all-digital/components/_tooltip-button.scss
@@ -1,0 +1,23 @@
+.tooltip-button__content {
+  width: 20rem;
+  box-shadow: 0 0 8px rgba(5, 18, 25, 0.25);
+  border-radius: 3px;
+  padding: 1.5rem;
+  font-size: 14px;
+  background: #fff;
+  color: #44484C;
+  transition: opacity .4s;
+  position: absolute;
+  z-index: 9001;
+  pointer-events: none;
+  overflow: auto;
+  opacity: 0;
+}
+.tooltip-button__mask {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  z-index: 9002;
+}


### PR DESCRIPTION
Adds the CSS required for `<TooltipButton />` in adc-ui-components.